### PR TITLE
Fix sidebar navigation arrow and flip it on collapse

### DIFF
--- a/features/layout/sidebar-navigation/menu-item-button.tsx
+++ b/features/layout/sidebar-navigation/menu-item-button.tsx
@@ -9,6 +9,7 @@ type MenuItemProps = {
   iconSrc: string;
   onClick: () => void;
   isCollapsed: boolean;
+  flipOnCollapse?: boolean;
 };
 
 export function MenuItemButton({
@@ -17,12 +18,20 @@ export function MenuItemButton({
   onClick,
   iconSrc,
   isCollapsed,
+  flipOnCollapse,
 }: MenuItemProps) {
   return (
     <li className={classNames(styles.listItem, className)}>
       <Button className={styles.anchor} onClick={onClick}>
         {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img className={styles.icon} src={iconSrc} alt={`${text} icon`} />{" "}
+        <img
+          className={classNames(
+            styles.icon,
+            flipOnCollapse && isCollapsed && styles.isCollapsed,
+          )}
+          src={iconSrc}
+          alt={`${text} icon`}
+        />{" "}
         {!isCollapsed && text}{" "}
       </Button>
     </li>

--- a/features/layout/sidebar-navigation/menu-item-link.module.scss
+++ b/features/layout/sidebar-navigation/menu-item-link.module.scss
@@ -29,4 +29,8 @@
 .icon {
   width: space.$s6;
   margin-right: space.$s3;
+
+  &.isCollapsed {
+    transform: scaleX(-1);
+  }
 }

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -91,6 +91,7 @@ export function SidebarNavigation() {
               isCollapsed={isSidebarCollapsed}
               onClick={() => toggleSidebar()}
               className={styles.collapseMenuItem}
+              flipOnCollapse={true}
             />
           </ul>
         </nav>


### PR DESCRIPTION
Added SCSS styling and an additional prop to enable optional flipping of MenuItemButton component.